### PR TITLE
Fix invalid build-backend in pyproject.toml (#9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "dawproject"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,51 @@
+"""Tests for packaging metadata in pyproject.toml.
+
+Guards against regressions like an invalid build-backend declaration
+(see GitHub issue #9).
+"""
+
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None
+
+PYPROJECT_PATH = pathlib.Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+@pytest.fixture(scope="module")
+def pyproject():
+    if tomllib is None:
+        pytest.skip("tomllib/tomli not available")
+    with open(PYPROJECT_PATH, "rb") as f:
+        return tomllib.load(f)
+
+
+class TestBuildSystem:
+    def test_build_backend_is_setuptools_build_meta(self, pyproject):
+        backend = pyproject["build-system"]["build-backend"]
+        assert backend == "setuptools.build_meta", (
+            f"build-backend should be 'setuptools.build_meta', got '{backend}'"
+        )
+
+    def test_build_backend_is_importable(self, pyproject):
+        backend = pyproject["build-system"]["build-backend"]
+        module_path = backend.split(":")[0]
+        try:
+            importlib.import_module(module_path)
+        except ModuleNotFoundError:
+            pytest.fail(f"build-backend module '{module_path}' is not importable")
+
+    def test_build_requires_includes_setuptools(self, pyproject):
+        requires = pyproject["build-system"].get("requires", [])
+        assert any("setuptools" in r for r in requires), (
+            "build-system.requires should include setuptools"
+        )


### PR DESCRIPTION
Replace non-existent 'setuptools.backends._legacy:_Backend' with the standard 'setuptools.build_meta' backend. Add regression tests to verify the build-backend is correct and importable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to build metadata and a small regression test; no runtime/library behavior is modified.
> 
> **Overview**
> Fixes packaging configuration by replacing the invalid `build-system.build-backend` value in `pyproject.toml` with the standard `setuptools.build_meta`.
> 
> Adds `tests/test_packaging.py` to parse `pyproject.toml` and assert the backend is exactly `setuptools.build_meta`, importable, and that `build-system.requires` includes `setuptools`, preventing future regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ea6546d8d8d1f6241ad6dbbb1273769a9c391d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->